### PR TITLE
[fixes #31] find now takes an optional first arg as an array

### DIFF
--- a/lib/find.js
+++ b/lib/find.js
@@ -3,6 +3,7 @@
 var Funnel = require('broccoli-funnel');
 var decompose = require('./utils/decompose');
 var debug = require('debug')('broccoli-stew:find');
+var merge = require('broccoli-merge-trees');
 
 /**
  * @example
@@ -48,11 +49,56 @@ var debug = require('debug')('broccoli-stew:find');
  * find(tree, { include: [/*.js/], exclude: [ 'bar.*' ]) => [
  *  'lib/foo.js'
  * ]);
+ *
+ * also given:
+ *   other/foo/bar.jcs
+ *   other/foo/bar.css
+ *   other/foo/package.json
+ *
+ * other = 'other';
+ *
+ * find([
+ *  root,
+ *  other
+ *]) => [
+ *   package.json
+ *   lib/bar.js
+ *   lib/foo.js
+ *   lib/bar.coffee
+ *   lib/bar.txt
+ *   foo/bar.jcs
+ *   foo/bar.css
+ * ]
+ **
+ * find([
+ *  root,
+ *  other
+ * ],'**//*.js') => [
+ *   lib/bar.js
+ *   lib/foo.js
+ * ]
+ *
  * @name find
  * @argument tree
  * @argument filter
  */
-module.exports = function find(tree, _options) {
+module.exports = function find(tree, options) {
+  var arity = arguments.length;
+
+  if (Array.isArray(tree)) {
+    return merge(tree.map(invokeFindWithCorrectArity(options, arity)));
+  } else {
+    return invokeFindWithCorrectArity(options, arity)(tree);
+  }
+};
+
+function invokeFindWithCorrectArity(options, arity) {
+  return function(tree) {
+    return arity > 1 ? _find(tree, options) : _find(tree);
+  };
+}
+
+function _find(tree, _options) {
   var options, root;
 
   if (arguments.length === 1) {
@@ -75,6 +121,7 @@ module.exports = function find(tree, _options) {
       options = {};
       var pattern = decompose.expandSingle(_options);
       var lastChar = pattern.charAt(pattern.length - 1);
+      options.destDir = root;
 
       if (lastChar === '*' || lastChar !== '/') {
         options.include = [pattern];
@@ -88,4 +135,5 @@ module.exports = function find(tree, _options) {
 
   debug('%s include: %o exclude: %o', root, options.include, options.exclude);
   return new Funnel(root, options);
-};
+}
+

--- a/package.json
+++ b/package.json
@@ -23,13 +23,14 @@
   "dependencies": {
     "broccoli-filter": "^0.1.10",
     "broccoli-funnel": "^0.1.7",
+    "broccoli-merge-trees": "^0.2.1",
     "chalk": "^0.5.1",
     "debug": "^2.1.0",
     "fs-extra": "^0.13.0",
     "lodash-node": "^2.4.1",
     "minimatch": "^2.0.1",
-    "walk-sync": "^0.1.3",
-    "rsvp": "^3.0.16"
+    "rsvp": "^3.0.16",
+    "walk-sync": "^0.1.3"
   },
   "devDependencies": {
     "broccoli": "^0.13.3",

--- a/tests/find-test.js
+++ b/tests/find-test.js
@@ -23,7 +23,7 @@ describe('find', function() {
 
   describe('rooted at: ' + fixturePath, function() {
     it('finds sub tree (folder no glob)', function() {
-      return find(fixturePath, 'node_modules/mocha/').then(function(files) {
+      return find('.', 'node_modules/mocha/').then(function(files) {
         expect(files).to.eql([
           'node_modules/mocha/mocha.css',
           'node_modules/mocha/mocha.js',
@@ -33,13 +33,13 @@ describe('find', function() {
     });
 
     it('finds sub tree (ambigious folder/file)', function() {
-      return find(fixturePath, 'node_modules/mocha').then(function(files) {
+      return find('.', 'node_modules/mocha').then(function(files) {
         expect(files).to.eql([]);
       });
     });
 
     it('finds sub tree (with glob)', function() {
-      return find(fixturePath, 'node_modules/mocha/**/*').then(function(files) {
+      return find('.', 'node_modules/mocha/**/*').then(function(files) {
         expect(files).to.eql([
           'node_modules/mocha/mocha.css',
           'node_modules/mocha/mocha.js',
@@ -49,7 +49,7 @@ describe('find', function() {
     });
 
     it('finds subtree via globed expansion', function() {
-      return find(fixturePath, 'node_modules/mocha/*.{css,js}').then(function(files) {
+      return find('.', 'node_modules/mocha/*.{css,js}').then(function(files) {
         expect(files).to.eql([
           'node_modules/mocha/mocha.css',
           'node_modules/mocha/mocha.js'
@@ -58,7 +58,7 @@ describe('find', function() {
     });
 
     it('finds subtree via globed expansion for a single file', function() {
-      return find(fixturePath, 'node_modules/mocha/{mocha.css}').then(function(files) {
+      return find('.', 'node_modules/mocha/{mocha.css}').then(function(files) {
         expect(files).to.eql([
           'node_modules/mocha/mocha.css'
         ]);
@@ -66,7 +66,7 @@ describe('find', function() {
     });
 
     it('finds subtree via dual glob + single expansion', function() {
-      return find(fixturePath, '*/mocha/*.css').then(function(files) {
+      return find('.', '*/mocha/*.css').then(function(files) {
         expect(files).to.eql([
           'node_modules/mocha/mocha.css',
           'other/mocha/apple.css',
@@ -75,7 +75,7 @@ describe('find', function() {
     });
 
     it('finds subtree via dual glob + double expansion', function() {
-      return find(fixturePath, 'node_modules/**/*.{js,css}').then(function(files) {
+      return find('.', 'node_modules/**/*.{js,css}').then(function(files) {
         expect(files).to.eql([
           'node_modules/foo/foo.css',
           'node_modules/mocha/mocha.css',
@@ -85,7 +85,7 @@ describe('find', function() {
     });
 
     it('root + matcher path with glob + double expansion', function() {
-      return find(fixturePath, 'node_modules/**/*.{js,css}').then(function(files) {
+      return find('.', 'node_modules/**/*.{js,css}').then(function(files) {
         expect(files).to.eql([
           'node_modules/foo/foo.css',
           'node_modules/mocha/mocha.css',
@@ -162,6 +162,47 @@ describe('find', function() {
       return find('node_modules/mocha/{mocha.css}').then(function(files) {
         expect(files).to.eql([
           'node_modules/mocha/mocha.css',
+        ]);
+      });
+    });
+  });
+
+  describe('find([])', function() {
+    it('multiple roots without globs', function() {
+      return find([
+        'node_modules/mocha',
+        'other/mocha'
+      ]).then(function(files) {
+        expect(files).to.eql([
+          'node_modules/mocha/mocha.css',
+          'node_modules/mocha/mocha.js',
+          'node_modules/mocha/package.json',
+          'other/mocha/apple.css',
+          'other/mocha/apple.js',
+        ]);
+      });
+    });
+
+    it('multiple roots with globs', function() {
+      return find([
+        'node_modules/mocha/*.js',
+        'other/mocha/*.js',
+      ]).then(function(files) {
+        expect(files).to.eql([
+          'node_modules/mocha/mocha.js',
+          'other/mocha/apple.js',
+        ]);
+      });
+    });
+
+    it('multiple roots + matcher path with glob + double expansion', function() {
+      return find([
+        'node_modules/mocha/',
+        'other/mocha/',
+      ], '**/*.js').then(function(files) {
+        expect(files).to.eql([
+          'node_modules/mocha/mocha.js',
+          'other/mocha/apple.js',
         ]);
       });
     });


### PR DESCRIPTION
* `find([tree, otherTree], optionalFilter)` now merges the two trees (which can themselves be globed strings)
* fix bug in rooted find, were having a string optionalFilter would result in an in-correct destDir (mostly a bug induced by the original testing setup)


TL;DR most uses of direct `broccolli-merge-trees` are no longer needed.