### PR TITLE
[Fix #38] Return dir not files from log

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -12,13 +12,13 @@ var DIR_REGEX  = /\/$/;
  *
  * log(tree);
  * // [cat.js, dog.js]
- * 
+ *
  * log(tree, {output: 'tree'});
  * // /Users/chietala/workspace/broccoli-stew/tmp/funnel-dest_Q1EeTD.tmp
  * // ├── cat.js
  * // └── dog.js
  *
- * 
+ *
  * @param  {String|Object} tree    The input tree to debug
  * @param  {Object} [options]
  * @property {String} [options.output] Print to stdout as a tree
@@ -40,7 +40,6 @@ module.exports = function log(tree, options) {
             console.log(printTree.stdout);
           }
 
-          return printTree.files;
         } else {
           var files = walkSync(dir).filter(function(path) {
             return !DIR_REGEX.test(path);
@@ -51,16 +50,17 @@ module.exports = function log(tree, options) {
           }
 
           console.log(files);
-          return files;
         }
+
+        return dir;
       }).catch(function(err) {
         console.log(err);
         throw err;
-      })
+      });
     },
     cleanup: function() {}
-  }
-}
+  };
+};
 
 function treeOutput(dir) {
   var end = '└── ',
@@ -70,11 +70,11 @@ function treeOutput(dir) {
 
   function tab(size) {
     var _tab = '   ';
-    return Array(size).join(_tab);
+    return new Array(size).join(_tab);
   }
 
   var files = walkSync(dir).map(function(path, i, arr) {
-    depth = path.split('/').length;
+    var depth = path.split('/').length;
     if (DIR_REGEX.test(path)) {
       stdout += (newLine + tab(depth - 1) + end + path);
     } else {
@@ -91,5 +91,5 @@ function treeOutput(dir) {
   return {
     stdout: stdout,
     files: files
-  }
+  };
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "devDependencies": {
     "broccoli": "^0.13.3",
     "chai": "^1.10.0",
-    "mocha": "^2.1.0"
+    "mocha": "^2.1.0",
+    "sinon": "^1.12.2"
   }
 }


### PR DESCRIPTION
Cleans up log tests to spy on console. Also log tests are idiomatic to the project. Closes #38 and verified in https://github.com/chadhietala/ember-performance. 