### PR TITLE
Ensure returned tree and debug tree contain the input data.

### DIFF
--- a/lib/debug.js
+++ b/lib/debug.js
@@ -17,7 +17,10 @@ module.exports = function(tree, options) {
 
     var debugDir = './DEBUG-' + options.name;
     var debugPath = path.resolve(path.join(debugDir, relativePath));
+
     fs.mkdirsSync(path.dirname(debugPath));
     fs.writeFileSync(debugPath, contents);
+
+    return contents;
   });
 };

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "broccoli": "^0.13.3",
-    "broccoli-test-helpers": "0.0.1",
+    "broccoli-test-helpers": "0.0.2",
     "chai": "^1.10.0",
     "mocha": "^2.1.0",
     "sinon": "^1.12.2"

--- a/tests/debug-test.js
+++ b/tests/debug-test.js
@@ -23,7 +23,9 @@ describe('debug', function() {
   });
 
   it('should have an array of files and directorys in the tree', function() {
-    return debug(_find('node_modules/mocha'), {name: 'debug'}).then(function(files) {
+    return debug(_find('node_modules/mocha'), {name: 'debug'}).then(function(results) {
+      var files = results.files;
+
       expect(files).to.eql([
         'node_modules/',
         'node_modules/mocha/',
@@ -35,7 +37,9 @@ describe('debug', function() {
   });
 
   it('should write files to disk in correct folder', function() {
-    return debug(_find('node_modules/mocha'), {name: 'debug'}).then(function(files) {
+    return debug(_find('node_modules/mocha'), {name: 'debug'}).then(function(results) {
+      var files = results.files;
+
       var base = 'tests/fixtures/';
       var debugDir = path.join(process.cwd(), base + 'DEBUG-debug');
       var fixture = path.join(process.cwd(), base + 'node_modules/mocha/mocha.js');

--- a/tests/find-test.js
+++ b/tests/find-test.js
@@ -23,7 +23,9 @@ describe('find', function() {
 
   describe('rooted at: ' + fixturePath, function() {
     it('finds sub tree (folder no glob)', function() {
-      return find('.', 'node_modules/mocha/').then(function(files) {
+      return find('.', 'node_modules/mocha/').then(function(results) {
+        var files = results.files;
+
         expect(files).to.eql([
           'node_modules/mocha/mocha.css',
           'node_modules/mocha/mocha.js',
@@ -33,13 +35,17 @@ describe('find', function() {
     });
 
     it('finds sub tree (ambigious folder/file)', function() {
-      return find('.', 'node_modules/mocha').then(function(files) {
+      return find('.', 'node_modules/mocha').then(function(results) {
+        var files = results.files;
+
         expect(files).to.eql([]);
       });
     });
 
     it('finds sub tree (with glob)', function() {
-      return find('.', 'node_modules/mocha/**/*').then(function(files) {
+      return find('.', 'node_modules/mocha/**/*').then(function(results) {
+        var files = results.files;
+
         expect(files).to.eql([
           'node_modules/mocha/mocha.css',
           'node_modules/mocha/mocha.js',
@@ -49,7 +55,9 @@ describe('find', function() {
     });
 
     it('finds subtree via globed expansion', function() {
-      return find('.', 'node_modules/mocha/*.{css,js}').then(function(files) {
+      return find('.', 'node_modules/mocha/*.{css,js}').then(function(results) {
+        var files = results.files;
+
         expect(files).to.eql([
           'node_modules/mocha/mocha.css',
           'node_modules/mocha/mocha.js'
@@ -58,7 +66,9 @@ describe('find', function() {
     });
 
     it('finds subtree via globed expansion for a single file', function() {
-      return find('.', 'node_modules/mocha/{mocha.css}').then(function(files) {
+      return find('.', 'node_modules/mocha/{mocha.css}').then(function(results) {
+        var files = results.files;
+
         expect(files).to.eql([
           'node_modules/mocha/mocha.css'
         ]);
@@ -66,7 +76,9 @@ describe('find', function() {
     });
 
     it('finds subtree via dual glob + single expansion', function() {
-      return find('.', '*/mocha/*.css').then(function(files) {
+      return find('.', '*/mocha/*.css').then(function(results) {
+        var files = results.files;
+
         expect(files).to.eql([
           'node_modules/mocha/mocha.css',
           'other/mocha/apple.css',
@@ -75,7 +87,9 @@ describe('find', function() {
     });
 
     it('finds subtree via dual glob + double expansion', function() {
-      return find('.', 'node_modules/**/*.{js,css}').then(function(files) {
+      return find('.', 'node_modules/**/*.{js,css}').then(function(results) {
+        var files = results.files;
+
         expect(files).to.eql([
           'node_modules/foo/foo.css',
           'node_modules/mocha/mocha.css',
@@ -85,7 +99,9 @@ describe('find', function() {
     });
 
     it('root + matcher path with glob + double expansion', function() {
-      return find('.', 'node_modules/**/*.{js,css}').then(function(files) {
+      return find('.', 'node_modules/**/*.{js,css}').then(function(results) {
+        var files = results.files;
+
         expect(files).to.eql([
           'node_modules/foo/foo.css',
           'node_modules/mocha/mocha.css',
@@ -95,7 +111,9 @@ describe('find', function() {
     });
 
     it('input tree, and string filter', function() {
-      return find(_find('node_modules/mocha/'), '**/*.js').then(function(files) {
+      return find(_find('node_modules/mocha/'), '**/*.js').then(function(results) {
+        var files = results.files;
+
         expect(files).to.eql([
           'node_modules/mocha/mocha.js',
         ]);
@@ -103,7 +121,9 @@ describe('find', function() {
     });
 
     it('input tree, not filter', function() {
-      return find(_find('node_modules/mocha/')).then(function(files) {
+      return find(_find('node_modules/mocha/')).then(function(results) {
+        var files = results.files;
+
         expect(files).to.eql([
           'node_modules/mocha/mocha.css',
           'node_modules/mocha/mocha.js',
@@ -113,7 +133,9 @@ describe('find', function() {
     });
 
     it('nested input tree and string filter', function() {
-      return find(_find(_find('node_modules'), '**/*.css')).then(function(files) {
+      return find(_find(_find('node_modules'), '**/*.css')).then(function(results) {
+        var files = results.files;
+
         expect(files).to.eql([
           'node_modules/foo/foo.css',
           'node_modules/mocha/mocha.css'
@@ -124,7 +146,9 @@ describe('find', function() {
 
   describe('unrooted', function() {
     it('finds sub tree', function() {
-      return find('node_modules/mocha').then(function(files) {
+      return find('node_modules/mocha').then(function(results) {
+        var files = results.files;
+
         expect(files).to.eql([
           'node_modules/mocha/mocha.css',
           'node_modules/mocha/mocha.js',
@@ -134,7 +158,9 @@ describe('find', function() {
     });
 
     it('finds subtree via globed expansion', function() {
-      return find('node_modules/mocha/*.{css,js}').then(function(files) {
+      return find('node_modules/mocha/*.{css,js}').then(function(results) {
+        var files = results.files;
+
         expect(files).to.eql([
           'node_modules/mocha/mocha.css',
           'node_modules/mocha/mocha.js',
@@ -143,7 +169,9 @@ describe('find', function() {
     });
 
     it('finds subtree via glob', function() {
-      return find('node_modules/mocha/*').then(function(files) {
+      return find('node_modules/mocha/*').then(function(results) {
+        var files = results.files;
+
         expect(files).to.eql([
           'node_modules/mocha/mocha.css',
           'node_modules/mocha/mocha.js',
@@ -153,7 +181,7 @@ describe('find', function() {
     });
 
     it('does not allow top level expansion', function() {
-      return find('{other,node_modules}/mocha/*.css').then(function(files) {
+      return find('{other,node_modules}/mocha/*.css').then(function(results) {
         throw new Error('should not get here');
       }, function(reason) {
         expect(reason.message).to.eq('top level glob or expansion not currently supported: `{other,node_modules}/mocha/*.css`');
@@ -169,7 +197,9 @@ describe('find', function() {
     });
 
     it('does allow 2nd level or more glob', function() {
-      return find('node_modules/*/*.css').then(function(files) {
+      return find('node_modules/*/*.css').then(function(results) {
+        var files = results.files;
+
         expect(files).to.eql([
           'node_modules/foo/foo.css',
           'node_modules/mocha/mocha.css',
@@ -178,7 +208,8 @@ describe('find', function() {
     });
 
     it('does allow 2nd level or more expansion', function() {
-      return find('node_modules/{mocha,}/*.css').then(function(files) {
+      return find('node_modules/{mocha,}/*.css').then(function(results) {
+        var files = results.files;
         expect(files).to.eql([
           'node_modules/mocha/mocha.css',
         ]);
@@ -186,7 +217,9 @@ describe('find', function() {
     });
 
     it('specific file, but no expansion', function() {
-      return find('node_modules/mocha/{mocha.css}').then(function(files) {
+      return find('node_modules/mocha/{mocha.css}').then(function(results) {
+        var files = results.files;
+
         expect(files).to.eql([
           'node_modules/mocha/mocha.css',
         ]);
@@ -199,7 +232,9 @@ describe('find', function() {
       return find([
         'node_modules/mocha',
         'other/mocha'
-      ]).then(function(files) {
+      ]).then(function(results) {
+        var files = results.files;
+
         expect(files).to.eql([
           'node_modules/mocha/mocha.css',
           'node_modules/mocha/mocha.js',
@@ -214,7 +249,9 @@ describe('find', function() {
       return find([
         'node_modules/mocha/*.js',
         'other/mocha/*.js',
-      ]).then(function(files) {
+      ]).then(function(results) {
+        var files = results.files;
+
         expect(files).to.eql([
           'node_modules/mocha/mocha.js',
           'other/mocha/apple.js',
@@ -226,7 +263,9 @@ describe('find', function() {
       return find([
         'node_modules/mocha/',
         'other/mocha/',
-      ], '**/*.js').then(function(files) {
+      ], '**/*.js').then(function(results) {
+        var files = results.files;
+
         expect(files).to.eql([
           'node_modules/mocha/mocha.js',
           'other/mocha/apple.js',

--- a/tests/log-test.js
+++ b/tests/log-test.js
@@ -29,7 +29,9 @@ describe('log', function() {
   });
 
   it('should print out the array of files in the tree', function() {
-    return log(_find('node_modules/mocha')).then(function(files) {
+    return log(_find('node_modules/mocha')).then(function(results) {
+      var files = results.files;
+
       expect(console.log.calledWith([
         'node_modules/mocha/mocha.css',
         'node_modules/mocha/mocha.js',
@@ -46,7 +48,9 @@ describe('log', function() {
   });
 
   it('should print out the tree of files to sdtout', function() {
-    return log(_find('node_modules/mocha'), {output: 'tree'}).then(function(files) {
+    return log(_find('node_modules/mocha'), {output: 'tree'}).then(function(results) {
+      var files = results.files;
+
       expect(console.log.calledWith('\n└── node_modules/\n'+
       '   └── node_modules/mocha/\n'+
       '      ├── node_modules/mocha/mocha.css\n'+
@@ -63,7 +67,9 @@ describe('log', function() {
   });
 
   it('should print out the tree of files to sdtout', function() {
-    return log(_find('node_modules/mocha'), {output: 'tree', label: 'log'}).then(function(files) {
+    return log(_find('node_modules/mocha'), {output: 'tree', label: 'log'}).then(function(results) {
+      var files = results.files;
+
       expect(console.log.calledWith(label('log') + '\n└── node_modules/\n'+
       '   └── node_modules/mocha/\n'+
       '      ├── node_modules/mocha/mocha.css\n'+
@@ -73,7 +79,9 @@ describe('log', function() {
   });
 
   it('should print out the array of files in the tree', function() {
-    return log(_find('node_modules/mocha'), {label: 'log'}).then(function(files) {
+    return log(_find('node_modules/mocha'), {label: 'log'}).then(function(results) {
+      var files = results.files;
+
       expect(console.log.calledWith(label('log'))).to.be.ok;
       expect(console.log.calledWith([
         'node_modules/mocha/mocha.css',

--- a/tests/map-test.js
+++ b/tests/map-test.js
@@ -34,7 +34,9 @@ describe('map', function() {
     it('identity', function() {
       return map(_find('node_modules/**/*'), function(content) {
         return content;
-      }).then(function(files) {
+      }).then(function(results) {
+        var files = results.files;
+
         expect(files['node_modules/foo/foo.css'       ]).to.eql(fixtureContent('node_modules/foo/foo.css'));
         expect(files['node_modules/mocha/mocha.css'   ]).to.eql(fixtureContent('node_modules/mocha/mocha.css'));
         expect(files['node_modules/mocha/mocha.js'    ]).to.eql(fixtureContent('node_modules/mocha/mocha.js'));
@@ -45,7 +47,9 @@ describe('map', function() {
     it('prepend', function() {
       return map(_find('node_modules/**/*'), function(content) {
         return 'hi\n' + content;
-      }).then(function(files) {
+      }).then(function(results) {
+        var files = results.files;
+
         expect(files['node_modules/foo/foo.css'       ]).to.eql('hi\n' + fixtureContent('node_modules/foo/foo.css'));
         expect(files['node_modules/mocha/mocha.css'   ]).to.eql('hi\n' + fixtureContent('node_modules/mocha/mocha.css'));
         expect(files['node_modules/mocha/mocha.js'    ]).to.eql('hi\n' + fixtureContent('node_modules/mocha/mocha.js'));
@@ -61,7 +65,9 @@ describe('map', function() {
         expect(relativePath).to.eql('node_modules/mocha/mocha.js');
         count++;
         return 'hi\n' + content;
-      }).then(function(files) {
+      }).then(function(results) {
+        var files = results.files;
+
         expect(count).to.eql(1);
         expect(files['node_modules/foo/foo.css'       ]).to.eql(fixtureContent('node_modules/foo/foo.css'));
         expect(files['node_modules/mocha/mocha.css'   ]).to.eql(fixtureContent('node_modules/mocha/mocha.css'));
@@ -73,7 +79,9 @@ describe('map', function() {
     it('prepend', function() {
       return map(_find('node_modules/**/*'), function(content) {
         return 'hi\n' + content;
-      }).then(function(files) {
+      }).then(function(results) {
+        var files = results.files;
+
         expect(files['node_modules/foo/foo.css'       ]).to.eql('hi\n' + fixtureContent('/node_modules/foo/foo.css'));
         expect(files['node_modules/mocha/mocha.css'   ]).to.eql('hi\n' + fixtureContent('/node_modules/mocha/mocha.css'));
         expect(files['node_modules/mocha/mocha.js'    ]).to.eql('hi\n' + fixtureContent('/node_modules/mocha/mocha.js'));

--- a/tests/mv-test.js
+++ b/tests/mv-test.js
@@ -24,7 +24,9 @@ describe('mv', function() {
 
   describe('tree + destination', function() {
     it('move into node_modules', function() {
-      return mv(_find('node_modules'), 'toy_modules').then(function(files) {
+      return mv(_find('node_modules'), 'toy_modules').then(function(results) {
+        var files = results.files;
+
         expect(files).to.eql([
           'toy_modules/node_modules/foo/foo.css',
           'toy_modules/node_modules/mocha/mocha.css',
@@ -35,7 +37,9 @@ describe('mv', function() {
     });
 
     it('find node_modules/mocha and move whole tree into toy_modules', function() {
-      return mv(_find('node_modules/mocha'), 'toy_modules').then(function(files) {
+      return mv(_find('node_modules/mocha'), 'toy_modules').then(function(results) {
+        var files = results.files;
+
         expect(files).to.eql([
           'toy_modules/node_modules/mocha/mocha.css',
           'toy_modules/node_modules/mocha/mocha.js',
@@ -47,7 +51,9 @@ describe('mv', function() {
 
   describe('tree + from + destination', function() {
     it('move subgraph with matcher', function() {
-      return mv(_find('node_modules'), 'node_modules/', 'toy_modules/').then(function(files) {
+      return mv(_find('node_modules'), 'node_modules/', 'toy_modules/').then(function(results) {
+        var files = results.files;
+
         expect(files).to.eql([
           'toy_modules/foo/foo.css',
           'toy_modules/mocha/mocha.css',
@@ -58,7 +64,9 @@ describe('mv', function() {
     });
 
     it('move file with matcher (exact match)', function() {
-      return mv(_find('node_modules'), 'node_modules/mocha/mocha.css', 'toy_modules/foo.css').then(function(files) {
+      return mv(_find('node_modules'), 'node_modules/mocha/mocha.css', 'toy_modules/foo.css').then(function(results) {
+        var files = results.files;
+
         expect(files).to.eql([
           'node_modules/foo/foo.css',
           'node_modules/mocha/mocha.js',
@@ -69,7 +77,9 @@ describe('mv', function() {
     });
 
     it('move files with matcher (expansion)', function() {
-      return mv(_find('node_modules'), 'node_modules/mocha/mocha.{css,js}', 'toy_modules/').then(function(files) {
+      return mv(_find('node_modules'), 'node_modules/mocha/mocha.{css,js}', 'toy_modules/').then(function(results) {
+        var files = results.files;
+
         expect(files).to.eql([
           'node_modules/foo/foo.css',
           'node_modules/mocha/package.json',
@@ -80,7 +90,9 @@ describe('mv', function() {
     });
 
     it('move files with matcher (glob + expansion)', function() {
-      return mv(_find('node_modules'), 'node_modules/*/mocha.{css,js}', 'toy_modules/').then(function(files) {
+      return mv(_find('node_modules'), 'node_modules/*/mocha.{css,js}', 'toy_modules/').then(function(results) {
+        var files = results.files;
+
         expect(files).to.eql([
           'node_modules/foo/foo.css',
           'node_modules/mocha/package.json',
@@ -91,7 +103,9 @@ describe('mv', function() {
     });
 
     it('move files with matcher (glob + expansion) another', function() {
-      return mv(_find('node_modules'), 'node_modules/mocha/mocha.{css,js}', 'toy_modules/').then(function(files) {
+      return mv(_find('node_modules'), 'node_modules/mocha/mocha.{css,js}', 'toy_modules/').then(function(results) {
+        var files = results.files;
+
         expect(files).to.eql([
           'node_modules/foo/foo.css',
           'node_modules/mocha/package.json',
@@ -102,7 +116,9 @@ describe('mv', function() {
     });
 
     it('move files with matcher (glob + expansion) another one', function() {
-      return mv(_find('node_modules'), 'node_modules/mocha/*.{css,js}', 'toy_modules/').then(function(files) {
+      return mv(_find('node_modules'), 'node_modules/mocha/*.{css,js}', 'toy_modules/').then(function(results) {
+        var files = results.files;
+
         expect(files).to.eql([
           'node_modules/foo/foo.css',
           'node_modules/mocha/package.json',
@@ -113,7 +129,9 @@ describe('mv', function() {
     });
 
     it('move files with matcher (glob + expansion) another another one', function() {
-      return mv(_find('node_modules'), 'node_modules/*/*.{css,js}', 'toy_modules/').then(function(files) {
+      return mv(_find('node_modules'), 'node_modules/*/*.{css,js}', 'toy_modules/').then(function(results) {
+        var files = results.files;
+
         expect(files).to.eql([
           'node_modules/mocha/package.json',
           'toy_modules/foo.css',
@@ -124,7 +142,9 @@ describe('mv', function() {
     });
 
     it('move subgraph with matcher!!', function() {
-      return mv(_find('node_modules'), 'node_modules/mocha/', 'toy_modules/').then(function(files) {
+      return mv(_find('node_modules'), 'node_modules/mocha/', 'toy_modules/').then(function(results) {
+        var files = results.files;
+
         expect(files).to.eql([
           'node_modules/foo/foo.css',
           'toy_modules/mocha.css',

--- a/tests/rm-test.js
+++ b/tests/rm-test.js
@@ -23,7 +23,9 @@ describe('rm', function() {
   });
 
   it('rm file', function() {
-    return rm('node_modules', 'mocha/mocha.css').then(function(files) {
+    return rm('node_modules', 'mocha/mocha.css').then(function(results) {
+      var files = results.files;
+
       expect(files).to.eql([
         'foo/foo.css',
         'mocha/mocha.js',
@@ -33,7 +35,9 @@ describe('rm', function() {
   });
 
   it('rm files', function() {
-    return rm('node_modules', 'mocha/mocha.css', 'mocha/package.json').then(function(files) {
+    return rm('node_modules', 'mocha/mocha.css', 'mocha/package.json').then(function(results) {
+      var files = results.files;
+
       expect(files).to.eql([
         'foo/foo.css',
         'mocha/mocha.js',
@@ -42,7 +46,9 @@ describe('rm', function() {
   });
 
   it('rm glob', function() {
-    return rm('node_modules', 'mocha/mocha.*').then(function(files) {
+    return rm('node_modules', 'mocha/mocha.*').then(function(results) {
+      var files = results.files;
+
       expect(files).to.eql([
         'foo/foo.css',
         'mocha/package.json',
@@ -51,7 +57,9 @@ describe('rm', function() {
   });
 
   it('rm glob at root', function() {
-    return rm('.', 'node_modules/mocha/mocha.js').then(function(files) {
+    return rm('.', 'node_modules/mocha/mocha.js').then(function(results) {
+      var files = results.files;
+
       expect(files).to.not.include('node_modules/mocha/mocha.js');
       expect(files).to.include('node_modules/mocha/package.json');
       expect(files).to.include('node_modules/foo/foo.css');
@@ -60,7 +68,9 @@ describe('rm', function() {
  
   // funnel doesn't really support this yet
   // it('rm glob at root, but negated', function() {
-  //   return rm('.', 'node_modules/mocha/mocha.js', '!node_modules/mocha/mocha.js').then(function(files) {
+  //   return rm('.', 'node_modules/mocha/mocha.js', '!node_modules/mocha/mocha.js').then(function(results) {
+  //   var files = results.files;
+  //
   //     expect(files).to.include('node_modules/mocha/mocha.js');
   //     expect(files).to.include('node_modules/mocha/package.json');
   //     expect(files).to.include('node_modules/foo/foo.css');


### PR DESCRIPTION
Requires https://github.com/chadhietala/broccoli-test-helpers/pull/1.

Previously, the output tree from `debug` would contain all of the correct files, but they would be empty (because we did not return the original content).