### PR TITLE
Bump test helper version

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "broccoli": "^0.13.3",
-    "broccoli-test-helpers": "0.0.2",
+    "broccoli-test-helpers": "0.0.3",
     "chai": "^1.10.0",
     "mocha": "^2.1.0",
     "sinon": "^1.12.2"


### PR DESCRIPTION
Changed `cleanupBuilders` to always return a promise. This is good for when the subject throws in the constructor and there isn't an actual build.

See https://github.com/chadhietala/broccoli-test-helpers/commit/6bcdb42006466c0686c1d23fb4c5cbcaad00f03f for detail.