### PR TITLE
First pass at adding `stew.callback` helper

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,5 +6,6 @@ module.exports = {
   map: require('./lib/map'),
   log: require('./lib/log'),
   debug: require('./lib/debug'),
-  rm: require('./lib/rm')
+  rm: require('./lib/rm'),
+  afterBuild: require('./lib/afterBuild')
 };

--- a/lib/afterBuild.js
+++ b/lib/afterBuild.js
@@ -1,0 +1,41 @@
+/**
+ * Returns a new tree that causes a callback to be called after every build of
+ * the passed inputTree
+ *
+ * @example
+ *
+ * var tree = find('zoo/animals/*.js');
+ *
+ * tree = stew.afterBuild(tree, function(outputDir) {
+ *   // Whatever debugging you'd like to do. Maybe mess with outputDir or maybe
+ *   // debug other state your Brocfile contains.
+ * });
+ *
+ *
+ * @param  {String|Object} tree    The desired input tree
+ * @param  {Function} callback     The function to call every time the tree is built
+ */
+module.exports = function afterBuild(tree, cb) {
+  if (tree === null || tree === undefined) {
+    throw new Error('No inputTree passed to stew.afterBuild');
+  }
+
+  if (typeof cb !== 'function') {
+    throw new Error('No callback passed to stew.afterBuild');
+  }
+
+  return {
+    read: function(readTree) {
+      return readTree(tree).then(function(dir) {
+        cb(dir);
+        return dir;
+      }).catch(function(err) {
+        console.log(err);
+        throw err;
+      });
+    },
+
+    cleanup: function() {}
+  };
+};
+

--- a/tests/afterBuild-test.js
+++ b/tests/afterBuild-test.js
@@ -1,0 +1,36 @@
+var _afterBuild = require('../lib/afterBuild');
+var path = require('path');
+var chai = require('chai');
+var sinon = require('sinon');
+var expect = chai.expect;
+var helpers = require('broccoli-test-helpers');
+var makeTestHelper = helpers.makeTestHelper;
+var cleanupBuilders = helpers.cleanupBuilders;
+
+
+describe('afterBuild', function() {
+  var emptyFixturePath = path.join(__dirname, 'fixtures', 'empty'),
+      spyFunc;
+
+  afterEach(function() {
+    return cleanupBuilders();
+  });
+
+  var afterBuild = makeTestHelper({
+    subject: _afterBuild,
+    fixturePath: emptyFixturePath
+  });
+
+  beforeEach(function() {
+    spyFunc = sinon.spy();
+  });
+
+  it('it called after the inputTree builds', function() {
+    expect(spyFunc.callCount).to.equal(0);
+
+    return afterBuild(emptyFixturePath, spyFunc).then(function(results) {
+      expect(spyFunc.callCount).to.equal(1);
+      expect(spyFunc.calledWith(sinon.match.string)).to.be.true;
+    });
+  });
+});

--- a/tests/api-test.js
+++ b/tests/api-test.js
@@ -11,5 +11,6 @@ describe('api', function() {
     expect(stew.log).a('function');
     expect(stew.debug).a('function');
     expect(stew.rm).a('function');
+    expect(stew.afterBuild).a('function');
   });
 });


### PR DESCRIPTION
It is a helper to simply call a callback after a tree has been built (has had its read method called). An example:

```js
var tree = find('zoo/animals/*.js');

tree = stew.callback(tree, function(outputDir) {
  // Whatever debugging you'd like to do. Maybe mess with outputDir or maybe
  // debug other state your Brocfile contains.
});
```

This helper is useful to me, because I’m constantly forgetting that the Brocfile is only setting up a tree of promises and only run once (at least when I’m quickly throwing in a debugging line).