### PR TITLE
Add dir option to debug

### DIFF
--- a/lib/debug.js
+++ b/lib/debug.js
@@ -15,7 +15,12 @@ module.exports = function(tree, options) {
       throw Error('Must pass folder name to write to.');
     }
 
-    var debugDir = './DEBUG-' + options.name;
+    var debugDir;
+    if (options.dir) {
+      debugDir = options.dir + '/' + options.name;
+    } else {
+      debugDir = './DEBUG-' + options.name;
+    }
     var debugPath = path.resolve(path.join(debugDir, relativePath));
 
     fs.mkdirsSync(path.dirname(debugPath));

--- a/tests/debug-test.js
+++ b/tests/debug-test.js
@@ -76,4 +76,23 @@ describe('debug', function() {
       })).to.equal(fs.readFileSync(fixture, {encoding: 'utf8'}));
     });
   });
+  
+  it('should write files to disk in correct folder with dir option', function() {
+    return debug(_find('node_modules/mocha'), {name: 'debug', dir: 'mydir'}).then(function(results) {
+      var files = results.files;
+
+      var base = 'tests/fixtures/';
+      var debugDir = path.join(process.cwd(), base + 'mydir/debug');
+      var fixture = path.join(process.cwd(), base + 'node_modules/mocha/mocha.js');
+
+      files.forEach(function(file) {
+        expect(fs.existsSync(path.join(debugDir, file))).to.be.ok;
+      });
+
+      expect(fs.readFileSync(path.join(debugDir, 'node_modules/mocha/mocha.js'), {
+        encoding: 'utf8'
+      })).to.equal(fs.readFileSync(fixture, {encoding: 'utf8'}));
+    });
+  });
+  
 });


### PR DESCRIPTION
I find this useful to encapsulate debut output in a single top-level directory. While a pattern works for `.gitignore`, it does not to block expensive code indexing in RubyMine for example. 