### PR TITLE
Bumping broccoli-test-helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "broccoli": "^0.13.3",
-    "broccoli-test-helpers": "0.0.3",
+    "broccoli-test-helpers": "0.0.4",
     "chai": "^1.10.0",
     "mocha": "^2.1.0",
     "sinon": "^1.12.2"


### PR DESCRIPTION
I have exposed the in scope builder in the returned `results`. While this project does not need to test rebuilds I would like like to keep abreast with the latest.

__Example Usage__

```
  it('should invalidate the cache if an addon changes', function () {
    var module = path.join(__dirname, '..', 'node_modules', 'my-addon');
    var target = path.join(module, 'index.js');

    return prePackager(find('.'), {
      entries: ['example-app']
    }).then(function(results) {
      expect(results.files).to.deep.equal([
        'ember-moment/helpers/ago.js',
        'ember-moment/helpers/duration.js',
        'ember-moment/helpers/moment.js',
        'example-app/app.js',
        'example-app/config/environment.js',
        'example-app/initializers/ember-moment.js',
        'example-app/router.js'
      ]);
    });
    var code = fs.readFileSync(target, 'utf-8');
    code = code.replace('other.something()', 'other.something()+1');
    return results.builder.build();
// ---------------^
  }).then(function(results) {
     var changedFile = fs.readFileSync(target, 'utf-8');
     expect(changedFile.indexOf('other.something()+1') > -1).to.be.ok();
  });
});
```