### PR TITLE
Stick Cauliflower-filter at 1.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "broccoli-funnel": "^0.2.3",
     "broccoli-merge-trees": "^0.2.1",
-    "cauliflower-filter": "^1.0.2",
+    "cauliflower-filter": "^1.0.4",
     "chalk": "^0.5.1",
     "debug": "^2.1.0",
     "fs-extra": "^0.13.0",


### PR DESCRIPTION
South of 1.0.4 there was a bug where directories would get written to CWD. In 1.0.4 that is fixed. See https://github.com/caitp/cauliflower-filter/pull/9 for more details.