### PR TITLE
Throw when options not passed

### DIFF
--- a/lib/debug.js
+++ b/lib/debug.js
@@ -23,7 +23,7 @@ module.exports = function debug(tree, options) {
       options = {
         name: options
       };
-    } else if (!options.name) {
+    } else if (!options || !options.name) {
       throw Error('Must pass folder name to write to.');
     }
 


### PR DESCRIPTION
`stew.debug(tree)` => Cannot read property 'name' of undefined