### PR TITLE
_find('apath') should be an identity

### DIFF
--- a/lib/find.js
+++ b/lib/find.js
@@ -121,8 +121,8 @@ function _find(tree, _options) {
   if (arguments.length === 1 && typeof root === 'string') {
     var decomposition = decompose(root);
 
-    if (decomposition.include === undefined &&
-        decomposition.exclude === undefined) {
+    if (decomposition.include.length === 0 &&
+        decomposition.exclude.length === 0) {
       return decomposition.root;
     }
 

--- a/tests/find-test.js
+++ b/tests/find-test.js
@@ -273,4 +273,9 @@ describe('find', function() {
       });
     });
   });
+
+  it('treats single string as identity', function() {
+    expect(_find('foo')).to.eql('foo');
+  });
+
 });


### PR DESCRIPTION
It's not possible to use find-as-merge with input trees that happen to
still be strings, because _find is incorrectly failing to notice that
each one should simply be an identity operation.

I added a test that covers this case, although the rest of the test
suite seems to be in bad shape for unrelated reasons.