### PR TITLE
Auto-generate the folder name when omitted

### DIFF
--- a/lib/debug.js
+++ b/lib/debug.js
@@ -1,5 +1,6 @@
 var path      = require('path');
 var fs        = require('fs-extra');
+var sanitize  = require('sanitize-filename');
 var map       = require('./map');
 
 /**
@@ -23,16 +24,28 @@ module.exports = function debug(tree, options) {
       options = {
         name: options
       };
-    } else if (!options.name) {
-      throw Error('Must pass folder name to write to.');
+    }
+
+    if (!options) {
+      options = {};
+    }
+
+    if (!options.name && tree) {
+      options.name = sanitize(tree.toString());
+    }
+
+    if (!options.name) {
+      throw Error('Must pass folder name to write to. stew.debug(tree, { name: "foldername" })');
     }
 
     var debugDir;
+
     if (options.dir) {
       debugDir = options.dir + '/' + options.name;
     } else {
       debugDir = './DEBUG-' + options.name;
     }
+
     var debugPath = path.resolve(path.join(debugDir, relativePath));
 
     fs.mkdirsSync(path.dirname(debugPath));

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "minimatch": "^2.0.1",
     "resolve": "^1.1.6",
     "rsvp": "^3.0.16",
+    "sanitize-filename": "^1.5.3",
     "walk-sync": "^0.1.3"
   },
   "devDependencies": {


### PR DESCRIPTION
I'm not so sure how I feel about using the annotation field for this since it's not guaranteed to be a safe filename, which is why I'm using sanitize-filename.  There also isn't a public API for _annotation, so I `toString` the tree which returns `tree._name + ': ' + tree._annotation`.

I'd be fine with going back to just descriptive error when `!options || !options.name`. 
