### PR TITLE
Remove lodash-node 2.4.1, which is deprecated.

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "debug": "^2.1.0",
     "ensure-posix-path": "^1.0.1",
     "fs-extra": "^0.13.0",
-    "lodash-node": "^2.4.1",
     "minimatch": "^2.0.1",
     "resolve": "^1.1.6",
     "rsvp": "^3.0.16",


### PR DESCRIPTION
[lodash-node 2.4.1][ld] is deprecated. However, since it isn't used by [broccoli-stew][], I simply removed it from `packages.json` instead of upgrading to [lodash v4][lodash]. I successfully ran `npm test` with both Node v5.5.0 and v0.10.18 on my development machine before submitting this pull request.

[ld]: https://github.com/lodash-archive/lodash-node
[broccoli-stew]: https://github.com/stefanpenner/broccoli-stew
[lodash]: https://github.com/lodash/lodash