### PR TITLE
Enable partial pattern match for debug log

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -41,7 +41,7 @@ module.exports = function log(tree, _options) {
         var debug;
 
         if (debugOnly) {
-          if (new RegExp(debugEnv).test(label)) {
+          if (new RegExp(debugEnv.replace(/\*/g, '.*?')).test(label)) {
             debug = debuggr(label);
             if (tree) {
               debug(printTree.stdout);

--- a/tests/log-test.js
+++ b/tests/log-test.js
@@ -180,6 +180,33 @@ describe('log', function() {
       });
     });
 
+    it('should print out the array of files in the tree for partial pattern match', function() {
+      process.env.DEBUG = '*test';
+      return log(_find('node_modules/mocha'), {
+        label: 'test',
+        debugOnly: true,
+        debugger: mockDebugger
+      }).then(function(results) {
+        var files = results.files;
+
+        expect(called[0]).to.eql([
+          'node_modules/',
+          'node_modules/mocha/',
+          'node_modules/mocha/mocha.css',
+          'node_modules/mocha/mocha.js',
+          'node_modules/mocha/package.json'
+        ]);
+
+        expect(files).to.eql([
+          'node_modules/',
+          'node_modules/mocha/',
+          'node_modules/mocha/mocha.css',
+          'node_modules/mocha/mocha.js',
+          'node_modules/mocha/package.json'
+        ]);
+      });
+    });
+
     it('should print out the tree of files to sdtout (as tree structure)', function() {
       return log(_find('node_modules/mocha'), {
         output: 'tree',


### PR DESCRIPTION
Currently if you use a partial match at the beginning of your debug pattern, `log` will blow up:

```
DEBUG=*test <run build>

...

SyntaxError: Invalid regular expression: /*test/: Nothing to repeat
      at new RegExp (<anonymous>)
      at lib/log.js:44:15
      at lib$rsvp$$internal$$tryCatch (node_modules/rsvp/dist/rsvp.js:1036:16)
      at lib$rsvp$$internal$$invokeCallback (node_modules/rsvp/dist/rsvp.js:1048:17)
      at lib$rsvp$$internal$$publish (node_modules/rsvp/dist/rsvp.js:1019:11)
      at Object.lib$rsvp$asap$$flush [as _onImmediate] (node_modules/rsvp/dist/rsvp.js:1198:9)
```

This can be avoided by converting plain `*` characters into a "match any multiple" kind of pattern. This is similar to how the `debug` module works when handling namespaces/patterns: https://github.com/visionmedia/debug/blob/master/debug.js#L144