### PR TITLE
Fix TypeError if env.DEBUG is node defined

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -40,8 +40,12 @@ module.exports = function log(tree, _options) {
         var printTree = treeOutput(dir);
         var debug;
 
+        if(typeof debugEnv === 'string') {
+          debugEnv = debugEnv.replace(/\*/g, '.*?');
+        }
+
         if (debugOnly) {
-          if (new RegExp(debugEnv.replace(/\*/g, '.*?')).test(label)) {
+          if (new RegExp(debugEnv).test(label)) {
             debug = debuggr(label);
             if (tree) {
               debug(printTree.stdout);

--- a/tests/log-test.js
+++ b/tests/log-test.js
@@ -142,6 +142,21 @@ describe('log', function() {
       return cleanupBuilders();
     });
 
+    it('shouldn\'t throw if there is no DEBUG env', function(done) {
+      function runMe() {
+        delete process.env.DEBUG;
+        return log(_find('node_modules/mocha'), {
+          label: 'test',
+          debugOnly: true,
+          debugger: mockDebugger
+        }).then(function() {
+          done();
+        });
+      }
+
+      expect(runMe).to.not.throw(TypeError);
+    });
+
     it('shouldn\'t print if the label doesn\'t match DEBUG env', function() {
       process.env.DEBUG = 'fhqwhgads';
       return log(_find('node_modules/mocha'), {


### PR DESCRIPTION
If there is no `DEBUG` specified, then you'll get an error:

```
TypeError: Cannot read property 'replace' of undefined
```

Because there is no sanity check before calling `replace()` on the value. This adds a sanity check and test.