### PR TITLE
s/rename/rm in example docs for `rm`

### DIFF
--- a/lib/rm.js
+++ b/lib/rm.js
@@ -5,7 +5,7 @@ var debug = require('debug')('broccoli-stew:rm');
  * remove files from a tree.
  *
  * @example
- * var rename = require('broccoli-stew').rm;
+ * var rm = require('broccoli-stew').rm;
  * var dist = 'lib';
  *
  * given:


### PR DESCRIPTION
Example docs copy referenced an unused variable.