### PR TITLE
Update `stew.debug` to leverage broccoli-debug.

### DIFF
--- a/lib/debug.js
+++ b/lib/debug.js
@@ -1,9 +1,6 @@
 'use strict';
 
-const path      = require('path');
-const fs        = require('fs-extra');
-const sanitize  = require('sanitize-filename');
-const map       = require('./map');
+const BroccoliDebug = require('broccoli-debug');
 
 /**
  * Writes the passed tree to disk at the root of
@@ -20,39 +17,36 @@ const map       = require('./map');
  * @param  {Object} options
  * @property {String} options.name The name of directory you want to write to
  */
-module.exports = function debug(tree, options) {
-  return map(tree, (contents, relativePath) => {
-    if (typeof options === 'string') {
-      options = {
-        name: options
-      };
-    }
+module.exports = function debug(tree, labelOrOptions) {
+  var options;
+  if (typeof labelOrOptions === 'string') {
+    options = {
+      name: labelOrOptions
+    };
+  } else {
+    options = labelOrOptions;
+  }
 
-    if (!options) {
-      options = {};
-    }
+  if (!options) {
+    options = {};
+  }
 
-    if (!options.name && tree) {
-      options.name = sanitize(tree.toString());
-    }
+  if (!options.name && tree) {
+    options.name = tree.toString();
+  }
 
-    if (!options.name) {
-      throw Error('Must pass folder name to write to. stew.debug(tree, { name: "foldername" })');
-    }
+  if (!options.name) {
+    throw Error('Must pass folder name to write to. stew.debug(tree, { name: "foldername" })');
+  }
 
-    let debugDir;
+  let broccoliDebugOptions = {
+    label: options.name,
+    force: true
+  };
 
-    if (options.dir) {
-      debugDir = options.dir + '/' + options.name;
-    } else {
-      debugDir = './DEBUG-' + options.name;
-    }
+  if (options.dir) {
+    broccoliDebugOptions.baseDir = options.dir;
+  }
 
-    let debugPath = path.resolve(path.join(debugDir, relativePath));
-
-    fs.mkdirsSync(path.dirname(debugPath));
-    fs.writeFileSync(debugPath, contents);
-
-    return contents;
-  });
+  return new BroccoliDebug(tree, broccoliDebugOptions);
 };

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "homepage": "https://github.com/stefanpenner/broccoli-stew",
   "dependencies": {
+    "broccoli-debug": "^0.6.1",
     "broccoli-funnel": "^1.0.1",
     "broccoli-merge-trees": "^1.0.0",
     "broccoli-persistent-filter": "^1.1.6",
@@ -38,7 +39,6 @@
     "minimatch": "^3.0.2",
     "resolve": "^1.1.6",
     "rsvp": "^3.0.16",
-    "sanitize-filename": "^1.5.3",
     "symlink-or-copy": "^1.1.8",
     "walk-sync": "^0.3.0"
   },

--- a/tests/debug-test.js
+++ b/tests/debug-test.js
@@ -17,7 +17,7 @@ describe('debug', function() {
 
   afterEach(() => {
     return cleanupBuilders(() => {
-      fs.removeSync(path.join(__dirname, 'fixtures/DEBUG-debug'));
+      fs.removeSync(path.join(process.cwd(), 'DEBUG'));
     });
   });
 
@@ -49,7 +49,7 @@ describe('debug', function() {
     files.forEach(file => {
       if (file.slice(-1) === '/') { return; }
 
-      let debugPath = path.join(fixturePath, 'DEBUG-debug', file);
+      let debugPath = path.join(process.cwd(), 'DEBUG', 'debug', file);
       let treeOutputPath = path.join(outputDir, file);
       let sourcePath = path.join(mochaFixturePath, file);
 
@@ -66,7 +66,7 @@ describe('debug', function() {
     let results = yield debug(mochaFixturePath, 'debug2');
     let outputDir = results.directory;
 
-    let debugPath = path.join(fixturePath, 'DEBUG-debug2');
+    let debugPath = path.join(process.cwd(), 'DEBUG', 'debug2');
     expect(fs.existsSync(debugPath)).to.be.true;
   }));
 
@@ -75,7 +75,7 @@ describe('debug', function() {
     let files = results.files;
 
     let base = 'tests/fixtures/';
-    let debugDir = path.join(process.cwd(), base + 'DEBUG-debug');
+    let debugDir = path.join(process.cwd(), 'DEBUG/debug');
     let fixture = path.join(process.cwd(), base + 'node_modules/mocha/mocha.js');
 
     files.forEach(file => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -109,6 +109,18 @@ braces@^1.8.2:
     preserve "^0.2.0"
     repeat-element "^1.1.2"
 
+broccoli-debug@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/broccoli-debug/-/broccoli-debug-0.6.1.tgz#aec612ba8e5419952f44dc78be52bfabcbc087f6"
+  dependencies:
+    broccoli-plugin "^1.2.1"
+    fs-tree-diff "^0.5.2"
+    heimdalljs "^0.2.1"
+    heimdalljs-logger "^0.1.7"
+    minimatch "^3.0.3"
+    sanitize-filename "^1.6.1"
+    tree-sync "^1.2.2"
+
 broccoli-funnel@^1.0.1:
   version "1.1.0"
   resolved "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.1.0.tgz#dfb91a37c902456456de4a40a1881948d65b27d9"
@@ -177,7 +189,7 @@ broccoli-persistent-filter@^1.1.6:
     symlink-or-copy "^1.0.1"
     walk-sync "^0.3.1"
 
-broccoli-plugin@^1.0.0, broccoli-plugin@^1.3.0:
+broccoli-plugin@^1.0.0, broccoli-plugin@^1.2.1, broccoli-plugin@^1.3.0:
   version "1.3.0"
   resolved "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.0.tgz#bee704a8e42da08cb58e513aaa436efb7f0ef1ee"
   dependencies:
@@ -917,7 +929,7 @@ mime@^1.2.11:
   version "1.3.4"
   resolved "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz#115f9e3b6b3daf2959983cb38f149a2d40eb5d53"
 
-"minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.2:
+"minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3:
   version "3.0.3"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz#2a4e4090b96b2db06a9d7df01055a62a77c9b774"
   dependencies:
@@ -1088,7 +1100,7 @@ pseudomap@^1.0.1:
   version "1.0.2"
   resolved "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
 
-quick-temp@^0.1.2, quick-temp@^0.1.3:
+quick-temp@^0.1.2, quick-temp@^0.1.3, quick-temp@^0.1.5:
   version "0.1.8"
   resolved "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.8.tgz#bab02a242ab8fb0dd758a3c9776b32f9a5d94408"
   dependencies:
@@ -1171,9 +1183,9 @@ sane@^1.4.1:
     walker "~1.0.5"
     watch "~0.10.0"
 
-sanitize-filename@^1.5.3:
+sanitize-filename@^1.6.1:
   version "1.6.1"
-  resolved "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.1.tgz#612da1c96473fa02dccda92dcd5b4ab164a6772a"
+  resolved "https://registry.yarnpkg.com/sanitize-filename/-/sanitize-filename-1.6.1.tgz#612da1c96473fa02dccda92dcd5b4ab164a6772a"
   dependencies:
     truncate-utf8-bytes "^1.0.0"
 
@@ -1250,9 +1262,19 @@ tmpl@1.0.x:
   version "1.0.4"
   resolved "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz#23640dd7b42d00433911140820e5cf440e521dd1"
 
+tree-sync@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/tree-sync/-/tree-sync-1.2.2.tgz#2cf76b8589f59ffedb58db5a3ac7cb013d0158b7"
+  dependencies:
+    debug "^2.2.0"
+    fs-tree-diff "^0.5.6"
+    mkdirp "^0.5.1"
+    quick-temp "^0.1.5"
+    walk-sync "^0.2.7"
+
 truncate-utf8-bytes@^1.0.0:
   version "1.0.2"
-  resolved "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz#405923909592d56f78a5818434b0b78489ca5f2b"
+  resolved "https://registry.yarnpkg.com/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz#405923909592d56f78a5818434b0b78489ca5f2b"
   dependencies:
     utf8-byte-length "^1.0.1"
 
@@ -1300,7 +1322,7 @@ username@^2.3.0:
 
 utf8-byte-length@^1.0.1:
   version "1.0.4"
-  resolved "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz#f45f150c4c66eee968186505ab93fcbb8ad6bf61"
+  resolved "https://registry.yarnpkg.com/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz#f45f150c4c66eee968186505ab93fcbb8ad6bf61"
 
 util-deprecate@^1.0.2:
   version "1.0.2"
@@ -1310,7 +1332,7 @@ utils-merge@1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz#0294fb922bb9375153541c4f7096231f287c8af8"
 
-walk-sync@^0.2.6:
+walk-sync@^0.2.6, walk-sync@^0.2.7:
   version "0.2.7"
   resolved "https://registry.npmjs.org/walk-sync/-/walk-sync-0.2.7.tgz#b49be4ee6867657aeb736978b56a29d10fa39969"
   dependencies:


### PR DESCRIPTION
This PR updates `stew.debug` to leverage [broccoli-debug](https://github.com/broccolijs/broccoli-debug) internally.

The only observable changes after landing this are:

* Debug folders are now nested inside of `DEBUG/**`.  I didn't consider this a breaking change, but @stefanpenner should confirm.
* Debug folders that are reused are properly sync'ed. Previously, the results of multiple builds were merged together making rebuild content non-trustworthy in a `DEBUG-*` folder.
* Supports binary files (e.g. does not write .png's as utf8 text). Previously, these files would be corrupted.